### PR TITLE
Adjusted map size & added circle map generation

### DIFF
--- a/src/components/terrain.rs
+++ b/src/components/terrain.rs
@@ -97,7 +97,7 @@ pub const CHUNK_SIZE: i32 = 16;
 /// Example: 8 = 8x16 = 128 blocks in each direction
 ///
 /// **NOTE:** Any value above 8 will cause an exponential performance drop
-pub const MAP_SIZE: i32 = 8;
+pub const MAP_SIZE: i32 = 6;
 
 /// Size of each block in pixels with 100% OS scaling.
 pub const CELL_SIZE: i32 = 80;


### PR DESCRIPTION
This pull request includes several changes to improve the terrain generation system and fix minor issues. The most important changes include reducing the map size, optimizing the terrain generation process, and fixing a typo in the documentation.

### Terrain Generation Improvements:
* [`src/components/terrain.rs`](diffhunk://#diff-288a18a1312c70291783b564c7dffa157a16c1d5c21575ba48f640f332d1f861L100-R100): Reduced `MAP_SIZE` from 8 to 6 to improve performance.
* [`src/systems/world_generator.rs`](diffhunk://#diff-9fe2652ea3d3dc0e0bd8ba7857ceb3d2707485d7d9aeda9f629049076581dab7L24-R25): Cloned `terrain_noise` and `material_noise` to avoid potential issues with shared references.
* [`src/systems/world_generator.rs`](diffhunk://#diff-9fe2652ea3d3dc0e0bd8ba7857ceb3d2707485d7d9aeda9f629049076581dab7R52-R109): Added logic to skip cells outside a circular area to optimize terrain generation.
* [`src/systems/world_generator.rs`](diffhunk://#diff-9fe2652ea3d3dc0e0bd8ba7857ceb3d2707485d7d9aeda9f629049076581dab7R120-R139): Introduced `is_border_cell` function to check if a cell is on the circular border.

### Documentation Fixes:
* [`src/systems/world_generator.rs`](diffhunk://#diff-9fe2652ea3d3dc0e0bd8ba7857ceb3d2707485d7d9aeda9f629049076581dab7L40-R40): Fixed a typo in the `generate_chunk` function documentation.